### PR TITLE
Linux cleanup & add linux notes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ $Worldsavelocation = "$env:USERPROFILE\AppData\LocalLow\IronGate\Valheim"
 
 ### Linux
 
-```
 Linux default settings have been pre-customized to suggested LinuxGSM dedicated server locations.
 
+```
 # Current user location (force set for crontab)
 HOME=/home/vhserver
 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,41 @@ Download the file and run it via Powershell.
 You can also edit the file with notepad (Notepad++ is better) and change the file saving locations. 
 By default the files save in the same folder the Valheim files are saved in (%username%\AppData\LocalLow\IronGate\ValheimBackups)
 
-HOW TO USE THIS SCRIPT: You can run it each day at any point, or you can setup a scheduled task that backs up this data for you. This works both on dedicated servers and on local saves. 
+## HOW TO USE THIS SCRIPT
 
+You can run it each day at any point, or you can setup a scheduled task that backs up this data for you. This works both on dedicated servers and on local saves. 
 
+Sample crontab:
+`0 */4 * * * /home/vhserver/valheimBackup.sh`
 
-Modifiable variables in the script:
+## Modifiable Variables
 
+### Windows
 
-# How many backups to keep before pruning older copies (Default is 10)
-$NumToKeep = 10
+# Number of backups to keep before pruning (default: 10)
+NumToKeep = 10
 
-# Where to save backups (Default is C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\ValheimBackups)
-$BackupFolderPath = "$env:USERPROFILE\AppData\LocalLow\IronGate\ValheimBackups"
+# Backup save location (default: C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\ValheimBackups)
+BackupFolderPath = "$env:USERPROFILE\AppData\LocalLow\IronGate\ValheimBackups"
 
-# Name of each unique backup file (This gets today's date and appends the file)
-$BackupName = Get-Date -Format "yyyyMMdd-HHmm"
+# Backup name format (default: current date prepended)
+BackupName = Get-Date -Format "yyyyMMdd-HHmm"
 
-# Server world file location (Default is C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\Valheim)
+# Server world data location (default: C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\Valheim)
 $Worldsavelocation = "$env:USERPROFILE\AppData\LocalLow\IronGate\Valheim"
 
+### Linux
 
+Linux default settings have been pre-customized to suggested LinuxGSM dedicated server locations.
 
+# Current user location (force set for crontab)
+HOME=/home/vhserver
 
-NOTES: LINUX VERSION MAY COME AS WELL
+# Number of backups to keep before pruning (default: 10)
+backupCount=10
+
+# Backup save location (default: $HOME/ValheimBackups/)
+backupLocation=$HOME/ValheimBackups/
+
+# Server world data location (default: $HOME/.config/unity3d/IronGate/Valheim)
+worldDir=$HOME/.config/unity3d/IronGate/Valheim

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Sample crontab:
 
 ### Windows
 
-# Number of backups to keep before pruning (default: 10)
+```
+## Number of backups to keep before pruning (default: 10)
 NumToKeep = 10
 
 # Backup save location (default: C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\ValheimBackups)
@@ -26,9 +27,11 @@ BackupName = Get-Date -Format "yyyyMMdd-HHmm"
 
 # Server world data location (default: C:\Users\(USERNAME)\Appdata\LocalLow\IronGate\Valheim)
 $Worldsavelocation = "$env:USERPROFILE\AppData\LocalLow\IronGate\Valheim"
+```
 
 ### Linux
 
+```
 Linux default settings have been pre-customized to suggested LinuxGSM dedicated server locations.
 
 # Current user location (force set for crontab)
@@ -42,3 +45,4 @@ backupLocation=$HOME/ValheimBackups/
 
 # Server world data location (default: $HOME/.config/unity3d/IronGate/Valheim)
 worldDir=$HOME/.config/unity3d/IronGate/Valheim
+```

--- a/ValheimBackupScript.sh
+++ b/ValheimBackupScript.sh
@@ -1,45 +1,27 @@
-### Valheim data backup script
-#Created by Wdrussell1/Demon1337/Casey Barrett
-### Backs up the entire appdata folder including characters/world data
-## Note: If you get errors running the script, run the following:
-## Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope CurrentUser
-#**************************************************************************
-## **************************CONFIGURATION ITEMS***************************
-#**************************************************************************
+HOME=/home/vhserver
 # How many backups to keep before pruning older copies (Default is 10)
-NumToKeep=10
+backupCount=10
 # Where to save backups (Default is $HOME/ValheimBackups/)
-BackupFolderPath=$HOME/ValheimBackups/
+backupLocation=$HOME/ValheimBackups/
 # Server world file location (Default is $HOME/Valheim)
-Worldsavelocation=$HOME/Valheim
-#**************************************************************************
-## ***********************END OF CONFIGURATION ITEMS***********************
-#**************************************************************************
-#**************************************************************************
-#*******************DO NOT MODIFY ANYTHING BEYOND THIS POINT***************
-#**************************************************************************
-#**************************************************************************
-#**************************************************************************
-## Main Script
+worldDir=$HOME/.config/unity3d/IronGate/Valheim
+
+format_date() {
+  date "+%Y-%m-%d-%H-%M-%S"
+}
+
 #Create the backup folder should it not exist
-if [[ ! -d $BackupFolderPath ]]
+if [[ ! -d $backupLocation ]]
 then
-    echo "$BackupFolderPath does not exist on your filesystem."
-	mkdir $BackupFolderPath
+  echo "Creating $backupLocation."
+  mkdir -p $backupLocation
 fi
-#
-#Get current date and time
-Date=$(date +%Y-%m-%d-%H-%M-%S)
-#
+
 #Put current date and time in the file name saving the TAR/ZIP in the file location you requested.
-tar -czvf $BackupFolderPath$Date.tar.gz $Worldsavelocation
-#
-#
-##Parsing backups 
-#Because linux..we have to add 1 to the NumToKeep variable
-Sum=`echo "$NumToKeep + 1" | bc`
-#
+tar -czvf $backupLocation/$(format_date).tar.gz $worldDir
+
+#Because linux..we have to add 1 to the backupCount variable
+Sum=`echo "$backupCount + 1" | bc`
+
 #Removing old backups
 ls -dt $HOME/ValheimBackups/* | tail -n +$Sum | xargs rm -rf
-#
-#


### PR DESCRIPTION
Hey,

I shortened the linux code a bit by removing some comments that are already in the Readme, plus the executionpolicy stuff which is windows exclusive. I also changed the date command to be a function so when the function is called it will calculate the date, instead of when the script starts. (Not a large difference with a small world, only a few seconds.)

I added -p to the mkdir command, and also made the README much more readable. I also added a sample crontab job for Linux, and set the default Linux values to a LinuxGSM dedicated server buildout.